### PR TITLE
Fixed rendering issue for Razor2

### DIFF
--- a/code/Meek/ContentVirtualFile.cs
+++ b/code/Meek/ContentVirtualFile.cs
@@ -28,10 +28,14 @@ namespace Meek
             var contentMarkup = content.Contents;
             var constructedContent = string.Empty;
 
+            var razorVersion = System.Configuration.ConfigurationManager.AppSettings["webpages:Version"];
+
             switch (_viewEngine.Type)
             {
                 case ViewEngineType.Razor:
-                    contentMarkup = contentMarkup.Replace("@", "@@");
+                    if (razorVersion != null 
+                        && razorVersion == "1.0.0.0")
+                        contentMarkup = contentMarkup.Replace("@", "@@");
                     contentMarkup = AddRazorEditLinkMarkup(contentMarkup, content.Partial);
                     constructedContent = string.Format(
                         "@{{ {0} ViewBag.Title = \"{1}\";}} {2}",


### PR DESCRIPTION
Razor2 does not have the same issue with unescaped @ symbols that Razor1
had.  So the @ to @@ replacement is no longer necessary.  Added a check
for the razor version but not sure this is the best way.
